### PR TITLE
Fixed generation of toast ids to be unique

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "iced_toasts"
 description = "An add-on crate for iced that provides toast notifications"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/Gomango999/iced-toasts"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -359,13 +359,15 @@ where
 
     /// Displays a new toast on-screen.
     pub fn push(&mut self, toast: Toast<Message>) {
+        let id = self.next_toast_id;
+        self.next_toast_id = self.next_toast_id.next();
         self.toasts.borrow_mut().push(toast::Toast {
-            id: self.next_toast_id,
+            id,
             expiry: time::Instant::now() + self.timeout_duration,
             level: toast.level,
             title: toast.title,
             message: toast.message,
-            on_dismiss: (self.on_dismiss)(self.next_toast_id),
+            on_dismiss: (self.on_dismiss)(id),
             action: toast
                 .action
                 .map(|(text, message)| (text.to_string(), message)),


### PR DESCRIPTION
The toast ID was actually not incremented when a new toast is added.

This causes all toasts that are active to dismissed when dismissing any single one.

I've fixed it so that it is incremented and also bumped the version.

Now only the actually dismissed toast is dismissed.